### PR TITLE
Fix parsing of JSONL files with null costUSD values (#2)

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -8,7 +8,7 @@ pub struct UsageRecord {
     pub timestamp: DateTime<Utc>,
     pub message: MessageData,
     #[serde(rename = "costUSD")]
-    pub cost_usd: f64,
+    pub cost_usd: Option<f64>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -56,7 +56,7 @@ impl From<&UsageRecord> for TokenUsage {
             output_tokens: record.message.usage.output_tokens,
             cache_creation_tokens: record.message.usage.cache_creation_input_tokens,
             cache_read_tokens: record.message.usage.cache_read_input_tokens,
-            total_cost: record.cost_usd,
+            total_cost: record.cost_usd.unwrap_or(0.0),
         }
     }
 }


### PR DESCRIPTION
## Summary
- Fixes issue #2 where June 3-4 data was not being displayed
- Updates JSONL parsing to handle new format with `costUSD: null`

## Problem
The new Claude Code JSONL format includes records with `costUSD: null` which caused deserialization failures. These records were silently skipped, resulting in missing data for recent dates.

## Solution
- Changed `UsageRecord.cost_usd` from `f64` to `Option<f64>` to handle nullable values
- Use `unwrap_or(0.0)` when converting to `TokenUsage` to default null costs to 0.0

## Result
- June 3rd data now appears correctly (188M tokens)
- Cost shows as $0.00 for records with null costUSD values
- No data loss - all valid records are now parsed

## Test Plan
- [x] Run `cargo test` - all tests pass
- [x] Run `cargo fmt` - code formatted
- [x] Test with `cargo run -- daily` - June 3rd data now appears
- [x] Verify backwards compatibility - June 1-2 data still displays correctly

Fixes #2

🤖 Generated with [Claude Code](https://claude.ai/code)