### PR TITLE
4-Fix parsing of JSONL files with null costUSD

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -8,7 +8,7 @@ pub struct UsageRecord {
     pub timestamp: DateTime<Utc>,
     pub message: MessageData,
     #[serde(rename = "costUSD")]
-    pub cost_usd: f64,
+    pub cost_usd: Option<f64>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -56,7 +56,7 @@ impl From<&UsageRecord> for TokenUsage {
             output_tokens: record.message.usage.output_tokens,
             cache_creation_tokens: record.message.usage.cache_creation_input_tokens,
             cache_read_tokens: record.message.usage.cache_read_input_tokens,
-            total_cost: record.cost_usd,
+            total_cost: record.cost_usd.unwrap_or(0.0),
         }
     }
 }


### PR DESCRIPTION
## Summary
- Fix parsing failure when JSONL files contain null costUSD values
- Ensures June 3-4 logs are properly displayed

## Changes
- Changed `cost_usd` field type from `f64` to `Option<f64>` in `UsageRecord` struct
- Updated `TokenUsage::from` implementation to handle None values with `unwrap_or(0.0)`

## Test Plan
- [x] Run `cargo test` - all tests pass
- [x] Run `cargo fmt` - code is properly formatted
- [x] Test with recent data: `cargo run -- --since 20250603 daily` - June 3rd data now appears
- [x] Verify backward compatibility with older JSONL files that have numeric costUSD values

## Fixes
Fixes #4

🤖 Generated with [Claude Code](https://claude.ai/code)