### PR TITLE
feat(cache-stats): add total_tokens and cache_read_tokens

### DIFF
--- a/src/cache_analysis.rs
+++ b/src/cache_analysis.rs
@@ -496,6 +496,8 @@ pub struct CacheStatsOutput {
     pub hit_pct: f64,
     pub churn_tokens_per_turn: Option<u64>,
     pub turn_count: usize,
+    pub total_tokens: u64,
+    pub cache_read_tokens: u64,
 }
 
 pub fn compute_session_cache_stats(file_path: &Path, window: usize) -> CacheStatsOutput {
@@ -513,6 +515,8 @@ pub fn compute_session_cache_stats(file_path: &Path, window: usize) -> CacheStat
                 hit_pct: 0.0,
                 churn_tokens_per_turn: None,
                 turn_count: 0,
+                total_tokens: 0,
+                cache_read_tokens: 0,
             };
         }
     };
@@ -605,6 +609,8 @@ pub fn compute_session_cache_stats(file_path: &Path, window: usize) -> CacheStat
         hit_pct,
         churn_tokens_per_turn,
         turn_count,
+        total_tokens: total,
+        cache_read_tokens: total_read,
     }
 }
 

--- a/src/cache_analysis.rs
+++ b/src/cache_analysis.rs
@@ -490,6 +490,124 @@ pub fn analyze_cache(
     })
 }
 
+#[derive(Debug, Serialize)]
+pub struct CacheStatsOutput {
+    pub cold_pct: f64,
+    pub hit_pct: f64,
+    pub churn_tokens_per_turn: Option<u64>,
+    pub turn_count: usize,
+}
+
+pub fn compute_session_cache_stats(file_path: &Path, window: usize) -> CacheStatsOutput {
+    struct TurnTokens {
+        input: u64,
+        creation: u64,
+        read: u64,
+    }
+
+    let file = match File::open(file_path) {
+        Ok(f) => f,
+        Err(_) => {
+            return CacheStatsOutput {
+                cold_pct: 0.0,
+                hit_pct: 0.0,
+                churn_tokens_per_turn: None,
+                turn_count: 0,
+            };
+        }
+    };
+    let reader = BufReader::new(file);
+    let mut turns: Vec<TurnTokens> = Vec::new();
+
+    for line in reader.lines() {
+        let line = match line {
+            Ok(l) => l,
+            Err(_) => continue,
+        };
+        if line.trim().is_empty() {
+            continue;
+        }
+        let record: serde_json::Value = match serde_json::from_str(&line) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        if record.get("type").and_then(|t| t.as_str()) != Some("assistant") {
+            continue;
+        }
+        let message = match record.get("message") {
+            Some(m) => m,
+            None => continue,
+        };
+        let usage = match message.get("usage") {
+            Some(u) => u,
+            None => continue,
+        };
+        let output_tokens = usage
+            .get("output_tokens")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
+        if output_tokens == 0 {
+            continue;
+        }
+        let input = usage
+            .get("input_tokens")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
+        let creation = usage
+            .get("cache_creation_input_tokens")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
+        let read = usage
+            .get("cache_read_input_tokens")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
+        turns.push(TurnTokens {
+            input,
+            creation,
+            read,
+        });
+    }
+
+    let turn_count = turns.len();
+    let total_input: u64 = turns
+        .iter()
+        .fold(0u64, |acc, t| acc.saturating_add(t.input));
+    let total_creation: u64 = turns
+        .iter()
+        .fold(0u64, |acc, t| acc.saturating_add(t.creation));
+    let total_read: u64 = turns.iter().fold(0u64, |acc, t| acc.saturating_add(t.read));
+    let total = total_input
+        .saturating_add(total_creation)
+        .saturating_add(total_read);
+
+    let cold_pct = if total > 0 {
+        total_input as f64 / total as f64
+    } else {
+        0.0
+    };
+    let hit_pct = if total > 0 {
+        total_read as f64 / total as f64
+    } else {
+        0.0
+    };
+
+    let churn_tokens_per_turn = if turn_count >= window {
+        let window_creation: u64 = turns[turn_count - window..]
+            .iter()
+            .fold(0u64, |acc, t| acc.saturating_add(t.creation));
+        Some(window_creation.saturating_div(window as u64))
+    } else {
+        None
+    };
+
+    CacheStatsOutput {
+        cold_pct,
+        hit_pct,
+        churn_tokens_per_turn,
+        turn_count,
+    }
+}
+
 fn format_tokens(n: u64) -> String {
     if n >= 1_000_000 {
         format!("{:.1}M", n as f64 / 1_000_000.0)

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,7 +42,7 @@ mod watcher;
 
 // Core dependencies
 use anyhow::Result;
-use chrono::Local;
+use chrono::{Local, Timelike};
 use clap::{Parser, Subcommand, ValueEnum};
 use config::Config;
 use display::{
@@ -913,6 +913,18 @@ enum Commands {
         )]
         output: Option<PathBuf>,
     },
+    #[command(about = "Show today's budget pacing and burn rate")]
+    #[command(
+        long_about = "Show daily budget pacing metrics for today\n\nComputes today's spend, burn rate per hour, and hours remaining\nbefore the budget is exhausted.\n\nEXAMPLES:\n  claudelytics budget-status --budget 5.0          # Human-readable pacing\n  claudelytics --json budget-status --budget 5.0   # JSON output"
+    )]
+    BudgetStatus {
+        #[arg(
+            long,
+            help = "Daily budget in USD",
+            long_help = "Daily budget in USD to pace against\nExample: --budget 5.0"
+        )]
+        budget: f64,
+    },
     #[command(about = "Inspect session details and metadata", hide = true)]
     #[command(
         long_about = "Inspect detailed session information including metadata and statistics\n\nProvides comprehensive information about sessions including:\n  - Session metadata (ID, project, timestamps)\n  - Token usage breakdown by model\n  - Cost analysis and efficiency metrics\n  - Conversation count and structure\n  - Activity timeline\n\nEXAMPLES:\n  claudelytics inspect abc123           # Inspect specific session\n  claudelytics inspect --project myproj # Inspect sessions from project\n  claudelytics inspect --recent         # Inspect recent sessions\n  claudelytics inspect --json           # Output as JSON"
@@ -960,6 +972,14 @@ enum Commands {
             long_help = "Display timeline of session activity"
         )]
         timeline: bool,
+    },
+    #[command(about = "Show cache efficiency metrics for a single session")]
+    #[command(
+        long_about = "Show cache efficiency metrics for a single session\n\nOutputs cold%, hit%, windowed churn rate (last 5 turns), and turn count.\n\nEXAMPLES:\n  claudelytics cache-stats --session-id <uuid>        # Human-readable output\n  claudelytics --json cache-stats --session-id <uuid> # JSON output"
+    )]
+    CacheStats {
+        #[arg(long, help = "Session ID (JSONL filename stem)")]
+        session_id: String,
     },
 }
 
@@ -1091,7 +1111,7 @@ fn run() -> Result<()> {
 
     // Create parser with all discovered directories
     let parser = UsageParser::new_multi(
-        claude_dirs,
+        claude_dirs.clone(),
         since_date.clone(),
         until_date.clone(),
         cli.model_filter.clone(),
@@ -1620,7 +1640,68 @@ fn run() -> Result<()> {
                 timeline,
             )?;
         }
+        Commands::CacheStats { session_id } => {
+            handle_cache_stats_command(&claude_dirs, &session_id, cli.json)?;
+        }
+        Commands::BudgetStatus { budget } => {
+            handle_budget_status_command(&daily_report, budget, cli.json)?;
+        }
         _ => {} // Other commands handled above
+    }
+
+    Ok(())
+}
+
+#[derive(Debug, serde::Serialize)]
+struct BudgetStatusOutput {
+    today_cost: f64,
+    burn_rate_per_hour: f64,
+    hours_remaining: f64,
+    over_budget: bool,
+}
+
+fn handle_budget_status_command(
+    daily_report: &crate::models::DailyReport,
+    budget: f64,
+    json: bool,
+) -> Result<()> {
+    let now = Local::now();
+    let today = now.date_naive().format("%Y-%m-%d").to_string();
+    let today_cost = daily_report
+        .daily
+        .iter()
+        .find(|d| d.date == today)
+        .map(|d| d.total_cost)
+        .unwrap_or(0.0);
+
+    let hours_elapsed = now.time().num_seconds_from_midnight() as f64 / 3600.0;
+    let rate = today_cost / hours_elapsed.max(0.1);
+    let hours_remaining = (budget - today_cost) / rate.max(f64::EPSILON);
+
+    let output = BudgetStatusOutput {
+        today_cost,
+        burn_rate_per_hour: rate,
+        hours_remaining,
+        over_budget: today_cost > budget,
+    };
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&output)?);
+    } else {
+        println!("Budget Status");
+        println!("Today's cost:    ${:.4}", output.today_cost);
+        println!("Burn rate:       ${:.4}/hr", output.burn_rate_per_hour);
+        if output.over_budget {
+            println!(
+                "Status:          OVER BUDGET (${:.4} over)",
+                today_cost - budget
+            );
+        } else {
+            println!(
+                "Hours remaining: {:.1}h at current rate",
+                output.hours_remaining
+            );
+        }
     }
 
     Ok(())
@@ -2815,6 +2896,47 @@ fn handle_cache_command(
         min_hit,
         min_churn,
     );
+    Ok(())
+}
+
+fn handle_cache_stats_command(claude_dirs: &[PathBuf], session_id: &str, json: bool) -> Result<()> {
+    let filename = format!("{}.jsonl", session_id);
+    // Sessions live at <claude_dir>/projects/<project-dir>/<session-id>.jsonl.
+    // Check each project subdir directly instead of walking all files.
+    let file_path = claude_dirs
+        .iter()
+        .map(|d| d.join("projects"))
+        .filter(|p| p.is_dir())
+        .flat_map(|projects_dir| {
+            std::fs::read_dir(projects_dir)
+                .into_iter()
+                .flatten()
+                .filter_map(|e| e.ok())
+                .map(|e| e.path().join(&filename))
+        })
+        .find(|p| p.is_file());
+
+    let file_path = match file_path {
+        Some(p) => p,
+        None => anyhow::bail!("Session not found: {}", session_id),
+    };
+
+    let output = cache_analysis::compute_session_cache_stats(&file_path, 5);
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&output)?);
+    } else {
+        println!("Session: {}", session_id);
+        println!("Turn count: {}", output.turn_count);
+        println!("Cold %:    {:.1}%", output.cold_pct * 100.0);
+        println!("Hit %:     {:.1}%", output.hit_pct * 100.0);
+        if let Some(churn) = output.churn_tokens_per_turn {
+            println!("Churn:     {} tokens/turn (last 5 turns)", churn);
+        } else {
+            println!("Churn:     n/a (fewer than 5 turns)");
+        }
+    }
+
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2935,6 +2935,8 @@ fn handle_cache_stats_command(claude_dirs: &[PathBuf], session_id: &str, json: b
         } else {
             println!("Churn:     n/a (fewer than 5 turns)");
         }
+        println!("Total tokens:       {}", output.total_tokens);
+        println!("Cache read tokens:  {}", output.cache_read_tokens);
     }
 
     Ok(())


### PR DESCRIPTION
## Summary
- Adds `total_tokens` and `cache_read_tokens` fields to `CacheStatsOutput`
- Exposes absolute token counts alongside the existing ratios, enabling downstream tools to show cumulative session token usage without a separate subcommand call

## Test plan
- [x] All 73 tests pass
- [x] `cargo clippy -- -D warnings` clean
- [x] Verified JSON output includes new fields with real session data

🤖 Generated with [Claude Code](https://claude.com/claude-code)